### PR TITLE
Adds additional feature of deleting comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -21,11 +21,13 @@ public final class Comment {
   private final String type;
   private final String msg;
   private final long timestamp;
+  private final long id;
 
-  public Comment(String name, String type, String msg, long timestamp) {
+  public Comment(String name, String type, String msg, long timestamp, long id) {
     this.name = name;
     this.type = type;
     this.msg = msg;
     this.timestamp = timestamp;
+    this.id = id;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -50,8 +50,9 @@ public class DataServlet extends HttpServlet {
       String type = (String) entity.getProperty("type");
       String msg = (String) entity.getProperty("msg");
       long timestamp = (long) entity.getProperty("timestamp");
+      long id = entity.getKey().getId();
 
-      Comment c = new Comment(name, type, msg, timestamp);
+      Comment c = new Comment(name, type, msg, timestamp, id);
       commentsList.add(c);
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentServlet.java
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet responsible for deleting tasks. */
+@WebServlet("/delete-comment")
+public class DeleteCommentServlet extends HttpServlet {
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    long id = Long.parseLong(request.getParameter("id"));
+
+    Key commentEntityKey = KeyFactory.createKey("Comment", id);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.delete(commentEntityKey);
+  }
+}

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -88,10 +88,30 @@ function createCommentElement(comment) {
   const msgElement = document.createElement('li');
   msgElement.innerText = comment.msg;
 
+  const deleteButtonElement = document.createElement('button');
+  deleteButtonElement.innerText = 'Delete';
+  deleteButtonElement.addEventListener('click', () => {
+    deleteComment(comment);
+
+    // Remove the task from the DOM.
+    commentElement.remove();
+  });
+
+  const brElement = document.createElement('br');
+
   commentElement.appendChild(nameElement);
   commentElement.appendChild(typeElement);
   commentElement.appendChild(msgElement);
+  commentElement.appendChild(deleteButtonElement);
+  commentElement.appendChild(brElement);
   return commentElement;
+}
+
+/** Tells the server to delete the comment. */
+function deleteComment(comment) {
+  const params = new URLSearchParams();
+  params.append('id', comment.id);
+  fetch('/delete-comment', {method: 'POST', body: params});
 }
 
 /** Function that calls writeText for the name in the hero header. */


### PR DESCRIPTION
**Description:** Implemented the additional feature that allows users to delete one or more comments. Permanently deletes from both the webpage and the datastore by clicking delete button under every comment. Holds even when page is refreshed/restarted. CSS/style elements have not been added yet, but the functionality is there.

**GIF of deletion (shows insertion, deletion, page refresh):**
![server-delete-comment](https://user-images.githubusercontent.com/20546276/83935600-e4cbee80-a76f-11ea-871b-18288f0b932e.gif)
